### PR TITLE
add routes property to now.json

### DIFF
--- a/now.json
+++ b/now.json
@@ -5,5 +5,11 @@
       "src": "packages/website/package.json",
       "use": "@now/next"
     }
+  ],
+  "routes": [
+    {
+      "src": "/(.*)",
+      "dest": "packages/website/$1"
+    }
   ]
 }


### PR DESCRIPTION
This PR adds a `routes` property to `now.json` so requests can reach the Next.js app and be served accordingly from the root domain `/(.*)`. 